### PR TITLE
mobile numpad at checkout

### DIFF
--- a/views/_macros/form-elements-bootstrap.html.twig
+++ b/views/_macros/form-elements-bootstrap.html.twig
@@ -207,7 +207,7 @@
 
 
     {% set attributes1 = attributes | merge({'id':'intlPhone', 'placeholder':'', 'onKeyPress':'return numbersonly(this, event)', 'maxlength':'16'}) %}
-    {% set attributes2 = attributes | merge({'id':'phone', 'placeholder':'', 'onKeyPress':'return numbersonly(this, event)', 'maxlength':'16'}) %}
+    {% set attributes2 = attributes | merge({'id':'phone', 'placeholder':'', 'onKeyPress':'return numbersonly(this, event)', 'maxlength':'16', pattern:'\\d*'}) %}
     {% import _self as elements %}
 
     <!--input id = "phone" type = "number" name="phone"-->
@@ -235,7 +235,7 @@
         $("#intlPhone").val(input.intlTelInput("getNumber"));
       });
     </script>
-    
+
 {% endmacro %}
 
 {% macro phonenumber(name, value='', attributes=[]) %}

--- a/views/checkout/billing.html.twig
+++ b/views/checkout/billing.html.twig
@@ -81,14 +81,14 @@
 							</div>
 							<div class="form-group">
 								<label class="control-label" for="checkout_card_number">Card Number <span class="text-danger">*</span></label>
-								{{ forms.text('checkout[card_number]', checkout.card_number, {id:'checkout_card_number',class:'form-control parsley-validated', placeholder:"Card Number", required:true, 'parsley-luhn': true, 'parsley-type': 'number'}) }}
+								{{ forms.text('checkout[card_number]', checkout.card_number, {id:'checkout_card_number',class:'form-control parsley-validated', placeholder:"Card Number", required:true, 'parsley-luhn': true, 'parsley-type': 'number',pattern:'\\d*'}) }}
 								<div class="validation">{{ forms.errorlist(form_errors, 'card_number') }}</div>
 							</div>
 							<div class="row">
 								<div class="col-xs-4">
 									<div class="form-group">
 										<label class="control-label" for="ccv">CVV2 <span class="text-danger">*</span></label>
-										{{ forms.text('checkout[card_cvv2]', checkout.card_cvv2, {class:'form-control parsley-validated', id:'ccv', placeholder:"CVV2", required:true, 'pattern':'^[0-9]{3,4}$'}) }}
+										{{ forms.text('checkout[card_cvv2]', checkout.card_cvv2, {class:'form-control parsley-validated', id:'ccv', placeholder:"CVV2", required:true, 'pattern':'\\d*'}) }}
 										<div class="validation">{{ forms.errorlist(form_errors, 'card_cvv2') }}</div>
 									</div>
 								</div>
@@ -159,7 +159,7 @@
 									{% endif %}
 								</div>
 							{% else %}
-								
+
 								<div class="checkout-display-address p" id="display_billing_address">
 									<p>{{ shipping_address }}</p>
 									<a class="btn btn-sm btn-secondary" href="{{ app.url }}/checkout/billing?clear=same">Change Address</a>


### PR DESCRIPTION
Forced numpad on mobile for credit card and cvv for checkout. Also added for phone fields. Seemingly not supported for certain android devices, might be an html5 issue. 
