### PR TITLE
search redirect feature

### DIFF
--- a/views/error.html.twig
+++ b/views/error.html.twig
@@ -2,7 +2,7 @@
 {% block title %}Page not found{% endblock %}
 {% block content %}
 <div class="content">
-    {% set response = api.get('redirect/resolve',{path: app.request.url}) %}
+    {% set response = api.get('redirect/resolve',{path: app.request.url, searchterm: false}) %}
     {% if response and response[0].destination %}
        {% do app.redirect(response[0].destination ,response[0].code) %}
     {% endif %}

--- a/views/search/default.html.twig
+++ b/views/search/default.html.twig
@@ -11,8 +11,18 @@
 {% if app.request.get.s|length < 2 %}
 	{% do app.redirect('/',[],'404') %}
 {% endif %}
+
+
+{% set response = api.get('redirect/resolve', {path: app.request.get.s, searchterm: true}) %}
+{% if response and response[0].destination %}
+   {% do app.redirect(response[0].destination ,response[0].code) %}
+{% endif %}
+
+
 {% block content %}
+
     {% set default_query = {"status":"active"} %}
     {% set default_attributes = "color,category_id,gender,size,price,review_score" %}
     {%include "/category/_partials/base.html.twig"%}
+
 {% endblock %}


### PR DESCRIPTION
Search redirects feature. 

Required repos: acendaAdminAngular (feature_search_redirects branch)
                           acenda (feature_search_redirect)
                           mia (feature_search_redirect)

Automatically redirect to a different page when the user enters a specific search term.
In Admin, go to settings -> Redirects. There are now 2 tabs: URL Redirects and Search Redirects. Switch to search Redirects and enter a pattern (e.g. "contact") and a destination ("/contact"). On the preview version of the site, you can now type "contact" in the search bar to go directly to the contact page. 

Supports regex (e.g. pattern = "\Acats?\z" destination = "/product/cat") to allow both "cat" and "cats".

Also added rule to limit to one unique pattern per tab.
