### PR TITLE
Fix shipping method

### DIFF
--- a/assets/js/estimator.js
+++ b/assets/js/estimator.js
@@ -7,6 +7,7 @@ function estimator() {
     .fail(function(error) {
     })
     .then(function(cart_data) {
+        sessionStorage.setItem('selected_shipping_method_checkout', shipping_method);
         $.post(acendaBaseUrl + '/api/shippingmethod/' + shipping_method + '/rate',{
             total:cart_data.result.subtotal,
             quantity:cart_data.result.item_count

--- a/assets/js/estimator.js
+++ b/assets/js/estimator.js
@@ -3,11 +3,11 @@ function estimator() {
     var shipping_method = $('#cart_shipping_method').val();
     var shipping_country = $('#cart_shipping_country').val();
     var shipping_state = $('#cart_shipping_state').val();
+
     $.getJSON(acendaBaseUrl + '/api/sessioncart')
     .fail(function(error) {
     })
     .then(function(cart_data) {
-        sessionStorage.setItem('selected_shipping_method_checkout', shipping_method);
         $.post(acendaBaseUrl + '/api/shippingmethod/' + shipping_method + '/rate',{
             total:cart_data.result.subtotal,
             quantity:cart_data.result.item_count
@@ -45,6 +45,9 @@ function estimator() {
     });
     return false;
 }
+$('#cart_shipping_method').change(function(e){
+    sessionStorage.setItem('selected_shipping_method_checkout', $('#cart_shipping_method').val());
+});
 
 $('#cart_Estimate').click(function(e) {
     e.preventDefault();

--- a/assets/js/region.js
+++ b/assets/js/region.js
@@ -153,12 +153,8 @@ if ($('.form-region').length) {
 				});
 			},
 			source: function(request, response) {
-				if (($('#checkout_shipping_address_id').val() != '' &&
-			        $('#checkout_shipping_address_id').val() != undefined) ||
-			        ($('#checkout_billing_address_id').val() != '' &&
-			        $('#checkout_billing_address_id').val() != undefined) ||
-			        ($('#express_shipping_address_id').val() != '' &&
-			        $('#express_shipping_address_id').val() != undefined)) {
+				if ($('#checkout_shipping_address_id').val() != '' &&
+			        $('#checkout_shipping_address_id').val() != undefined) {
 						return;
 					}
 				//console.log('3')

--- a/assets/js/region.js
+++ b/assets/js/region.js
@@ -68,10 +68,16 @@ if ($('.form-region').length) {
 						$.getJSON(acendaBaseUrl + '/api/shippingmethod/byregion?'+search_string, function(data) {
 							var dropdown = $( "#shipping_method" );
 							dropdown.empty();
+							var shippingMethod = sessionStorage.getItem('selected_shipping_method_checkout');
+							sessionStorage.setItem('selected_shipping_method_checkout', null);
 							if (typeof data.result !== 'undefined' && data.result.length > 0) {
 								$.each(data.result, function( index, method ) {
 									var option = $('<option></option>').attr("value", method.id).text(method.name+" ("+method.bottom_days_range+" to "+method.top_days_range+" days)");
 									dropdown.append(option);
+									if(shippingMethod && method.id == shippingMethod){
+										dropdown.val(shippingMethod);
+									};
+
 								});
 								$("select[id$=checkout_shipping_address_id]").prop("disabled",false);
 							} else {
@@ -147,11 +153,19 @@ if ($('.form-region').length) {
 				});
 			},
 			source: function(request, response) {
+				if (($('#checkout_shipping_address_id').val() != '' &&
+			        $('#checkout_shipping_address_id').val() != undefined) ||
+			        ($('#checkout_billing_address_id').val() != '' &&
+			        $('#checkout_billing_address_id').val() != undefined) ||
+			        ($('#express_shipping_address_id').val() != '' &&
+			        $('#express_shipping_address_id').val() != undefined)) {
+						return;
+					}
 				//console.log('3')
 				if(telReady)
 					$("#phone").intlTelInput("setCountry", $('select[id$=country]').val().toLowerCase());
-
 				$.getJSON(acendaBaseUrl + '/api/region/states/'+$('select[id$=country]').val(), request, function(data) {
+
 					var state = $('[id$=\\[state_select\\]]').val();
 					if ((state == undefined || state == '') && data.result.length > 0) {
 						console.log('no default State')
@@ -187,6 +201,7 @@ if ($('.form-region').length) {
 							};
 						}));
 					}
+
 					var search_string = "country="+$('select[id$=country]').val();
 					if ($('#state').val()) {
 						search_string = search_string + '&state=' + $('#state').val();

--- a/assets/js/region.js
+++ b/assets/js/region.js
@@ -482,7 +482,6 @@ if ($('.form-estimate').length) {
 									var option = $('<option></option>').attr("value", method.id).text(method.name);
 									dropdown.append(option);
 								});
-
 								dropdown.prop("disabled",false);
 							}
 						});
@@ -511,6 +510,7 @@ if ($('.form-estimate').length) {
 							value: item.id
 						};
 					}));
+					$('#cart_shipping_method').change();
 					//
 					console.log('call sCO() from form-estimate METHOD')
 					initCountryOpts()

--- a/views/cart/_partials/estimator.html.twig
+++ b/views/cart/_partials/estimator.html.twig
@@ -77,7 +77,7 @@
 					</div>
 				</div>
 				{# End shipping rate #}
-				
+
 				{# Begin arrival date #}
 				<div class="arrival p" id="block-date-estimate">
 					<div class="row">

--- a/views/cart/index.html.twig
+++ b/views/cart/index.html.twig
@@ -132,7 +132,7 @@ Cart
 {% if shipping_methods is empty or shipping_countries is empty %}
 
 	<p>Acenda is not properly set up for checkout. Please add an active shipping method with at least one valid shipping zone.</p>
-	
+
 {% else %}
 {% if (cart.items is empty) %}
 
@@ -141,13 +141,13 @@ Cart
 
 {% else %}
 <section id="shopping-cart">
-	
+
 	<h1>Shopping Cart</h1>
-	
+
 	{{ forms.begin('cart','','post', {class:'form-cart p divide'}) }}
 	{% for id, item in cart.items %}
 	{% set product = products[item.product_id].0 %}
-	
+
 	<div class="divide p pad-b g">
 	<div class="media media-cart">
 		{# Begin item image #}


### PR DESCRIPTION
1. Fixed issue where if a saved address is loaded by default in checkout, the shipping methods dropdown would have no options. 
2. Added feature where selecting a shipping method in cart would select the same shipping method at checkout, if possible. This only works when both:
   a) the shipping method dropdown is populated when checkout first loads. 
   and
   b) the shipping method dropdown contains the same method as the one selected at cart. 
   Otherwise, the normal course of action is taken. 
