### PR TITLE
Changed error message as per gavin’s request

### DIFF
--- a/views/checkout/_partials/final.html.twig
+++ b/views/checkout/_partials/final.html.twig
@@ -18,7 +18,7 @@
 {% if final_order is not empty %}
 	<h1>Checkout Complete!</h1>
 {% else %}
-	<h1><i class="fa fa-exclamation-circle"></i><span>Order Failed!</span></h1>
+	<h1><i class="fa fa-exclamation-circle"></i><span>Please check to make sure the Billing Address you entered matching the address associated with your credit card statement.</span></h1>
 {% endif %}
 {# Calculate subtotal without discounts #}
 {% set subtotal = 0 %}


### PR DESCRIPTION
https://trello.com/c/CBuKF5bk/2345-check-the-error-message-in-checkout-if-you-have-the-wrong-address-for-a-credit-card-it-shows-order-failed-scary-it-should-show-a

Check that failed orders have appropriate messages on the error page.
