### PR TITLE
Add verify parameter for new email api request.

### DIFF
--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -15,7 +15,8 @@ $('#SignupButton').click(function() {
 	}
 	$(this).prop('disabled', true).addClass('wait');
 	$.post(acendaBaseUrl + '/api/email', {
-		email: $('#SignupInput').val()
+		email: $('#SignupInput').val(),
+		verify:true
 	}).done(function(response) {
 		$('#SignupButton').prop('disabled', false).removeClass('wait');
 		$('html').append('<div class="flash-note affix alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Thank you for signing up.</div>');


### PR DESCRIPTION
Three branches:

https://github.com/torreycommerce/acenda/tree/feature-briteverify
https://github.com/torreycommerce/acendaAdminAngular/tree/feature-briteverify
https://github.com/torreycommerce/mia/tree/feature-briteverify

Go to your Site settings > Email > BriteVerify, and enter an API Key for that service.

In the footer of your store, there's an email subscription field (Be the first to know about new products and sales.) This now uses briteverify to reject certain emails like something@gmal.com