### PR TITLE
Add country to product review.

### DIFF
--- a/assets/js/region.js
+++ b/assets/js/region.js
@@ -123,7 +123,14 @@ if ($('.form-region').length) {
 				$('#state-label').prop('for','state_input');
 				$("#state_select").addClass('hidden-x').prop( "disabled", true )
                 $('select#state_select').parent().removeClass('has-error');
-				$.getJSON(acendaBaseUrl + '/api/shippingmethod/country', request, function(data) {
+                
+                var url = acendaBaseUrl + '/api/shippingmethod/country';
+                if( $("#country").data('allcountries') )
+                {
+                    url = acendaBaseUrl + '/api/region';
+                }
+                
+				$.getJSON(url, request, function(data) {
 					var country = (typeof countrySelect !== 'undefined')?countrySelect:$('[name$=\\[country_select\\]]').val();
 					if ((country == undefined || country == '') && data.result.length > 0) {
 						//data.result.sort(function(a, b) { return a.value > b.value});

--- a/views/review/default.html.twig
+++ b/views/review/default.html.twig
@@ -65,7 +65,12 @@
 		</div>
 		<div class="form-group fgq">
 			<label for="country">Country</label>
-			{{ form.text('review[country]',review.country|default(address.country), {class:'form-control parsley-validated', id:'country', placeholder:"Country", required:true}) }}
+			
+            {#{ form.text('review[country]',review.country|default(address.country), {class:'form-control parsley-validated', id:'country', placeholder:"Country", required:true}) }#}
+            {{ form.select('review[country]', review.country, {}, {required:true, class:'form-control parsley-validated', id:'country', 'data-allcountries':true }) }}
+        	{{ form.hidden('review[country_select]', review.country) }}
+            
+            
 			<div class="validation">{{ form.errorlist(form_errors, 'country') }}</div>
 		</div>
 		<div class="row">
@@ -79,9 +84,12 @@
 			
 			<div class="col-6">
 				<div class="form-group fgq">
-					<label id="state-label" for="state_input">State/Province</label>
-					{# form.select('review[state]',review.state|default(review.state), {}, {class:'form-control parsley-validated', id:'state_select', placeholder:"State"}) #}
-					{{ form.text('review[state]', review.state|default(review.state), {class:'form-control parsley-validated', placeholder:"State/Province", id:'state_input'}) }}
+					<label id="state-label" for="state_select">State/Province</label>
+                    
+					{{ form.select('review[state]',review.state|default(review.state), {}, {class:'form-control parsley-validated', id:'state_select', placeholder:"State"}) }}
+                    {#{ form.hidden('review[state_select]', review[name ~ 'state']) }#}
+					
+                    {{ form.text('review[state]', review.state|default(review.state), {class:'form-control parsley-validated', placeholder:"State/Province", id:'state_input'}) }}
 					<div class="validation">{{ form.errorlist(form_errors, 'state') }}</div>
 				</div>
 			</div>
@@ -120,4 +128,9 @@
 {% endblock %}
 {% block js %}
 {{ app.asset.js(app.url_asset ~ '/assets/js/rating.js') }}
+
+
+{{ app.asset.js(app.url_asset ~ '/assets/js/jquery.cascadingdropdown.js') }}
+{{ app.asset.js(app.url_asset ~ '/assets/js/region.js') }}
+
 {% endblock %}


### PR DESCRIPTION
Two branches:

https://github.com/torreycommerce/acenda/tree/feature-productreview-country
https://github.com/torreycommerce/mia/tree/feature-productreview-country

In the store preview, test the product review. There is now a country dropdown, which should list every country.
When selecting certain countries like USA, the State field will be a dropdown, otherwise it's a text.

Once submitting a few reviews, check the Products > Product Reviews section in the admin for the correct country and state fields.